### PR TITLE
removed hazelcast-spring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,6 @@
 		</dependency>
 		<dependency>
 			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast-spring</artifactId>
-			<version>3.8.2</version>
-		</dependency>
-		<dependency>
-			<groupId>com.hazelcast</groupId>
 			<artifactId>hazelcast-all</artifactId>
 			<version>3.8.2</version>
 		</dependency>


### PR DESCRIPTION
`hazelcast-all` includes `hazelcast-spring`. `hazelcast-spring` brings extra `hazelcast` dependency (version retrieved from spring boot versions).